### PR TITLE
check whether known compilers match FC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,13 @@ $(info fortran flags given: $(FFLAGS))
 ifeq ($(FC),)
  $(error Set environment variable FC with Fortran compiler!)
 else
- ifeq ($(FC),gfortran)
+ ifeq ($(findstring gfortran,$(FC)),gfortran)
   FFLAGS+= -O3 -H -ffree-form -Wall
  else
-  ifeq ($(FC),ifort)
+  ifeq ($(findstring ifort,$(FC)),ifort)
    FFLAGS+= -O3 -free -warn all -assume protect_parens -nogen-interfaces
   else
-   ifeq ($(FC),pgf95)
+   ifeq ($(findstring pgf95,$(FC)),pgf95)
     FFLAGS+= -O4 -fast -fastsse -Mfree -Mlarge_arrays -Mcache_align -Msmart -Msmartalloc -Minform=inform
    else
     $(error Unknown Fortran compiler. Set environment variable FC to either: ifort, gfortran, or pgf95!)


### PR DESCRIPTION
instead of comparing them directly it is probably
better to search for a substring to make sure
that the user can also specify e.g. FC=/usr/bin/gfortran
