### PR TITLE
Increase minimum required CMake version

### DIFF
--- a/.gersemirc
+++ b/.gersemirc
@@ -1,0 +1,4 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/BlankSpruce/gersemi/0.26.0/gersemi/configuration.schema.json
+
+indent: 2

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Apply pre-commit fixes
+de9b6f7f44ebd0b756f27adb24cf044b72a02f9d

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+---
+fail_fast: false
+repos:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-yaml
+  - repo: https://github.com/BlankSpruce/gersemi
+    rev: 0.26.0
+    hooks:
+      - id: gersemi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,8 @@ set(ENV{LAPLACE_ROOT} ${CMAKE_INSTALL_PREFIX})
 set(TEST_SOURCES ${PROJECT_SOURCE_DIR}/src/test_laplace.F90)
 
 # creates test suite
-add_executable(test_laplace ${TEST_SOURCES} ${SOURCES})
+add_executable(test_laplace ${TEST_SOURCES})
+target_link_libraries(test_laplace laplace-minimax)
 
 # take care of test
 find_program(BASH_PROGRAM bash)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,51 +6,50 @@ enable_testing()
 
 # special compiler flags
 if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
-  set(CMAKE_Fortran_FLAGS
-      "${CMAKE_Fortran_FLAGS} -O3 -H -ffree-form -Wall"
-     )
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -O3 -H -ffree-form -Wall")
 endif()
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
-  set(CMAKE_Fortran_FLAGS
-      "${CMAKE_Fortran_FLAGS}  -O3 -free -warn all -assume protect_parens -nogen-interfaces"
-     )
+  set(
+    CMAKE_Fortran_FLAGS
+    "${CMAKE_Fortran_FLAGS}  -O3 -free -warn all -assume protect_parens -nogen-interfaces"
+  )
 endif()
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES PGI)
-  set(CMAKE_Fortran_FLAGS
-      "${CMAKE_Fortran_FLAGS}  -O4 -fast -fastsse -Mfree -Mlarge_arrays -Mcache_align -Msmart -Msmartalloc -Minform=inform"
-     )
+  set(
+    CMAKE_Fortran_FLAGS
+    "${CMAKE_Fortran_FLAGS}  -O4 -fast -fastsse -Mfree -Mlarge_arrays -Mcache_align -Msmart -Msmartalloc -Minform=inform"
+  )
 endif()
 
 # Header files
-include_directories(    ${PROJECT_SOURCE_DIR}/inc 
-    )
+include_directories(${PROJECT_SOURCE_DIR}/inc)
 
 # source files
-set(SOURCES
-    ${PROJECT_SOURCE_DIR}/inc/consts.h
-    ${PROJECT_SOURCE_DIR}/inc/laplace_minimax.h
-    ${PROJECT_SOURCE_DIR}/src/dd128_arithmetics.F90
-    ${PROJECT_SOURCE_DIR}/src/dd128_linalg.F90
-    ${PROJECT_SOURCE_DIR}/src/lap_rderror.F90
-    ${PROJECT_SOURCE_DIR}/src/lap_rddata.F90
-    ${PROJECT_SOURCE_DIR}/src/lap_paraopt.F90 
-    ${PROJECT_SOURCE_DIR}/src/lap_maehly.F90
-    ${PROJECT_SOURCE_DIR}/src/lap_rmsd.F90
-    ${PROJECT_SOURCE_DIR}/src/lap_numlap.F90
-    ${PROJECT_SOURCE_DIR}/src/laplace_minimax.F90
+set(
+  SOURCES
+  ${PROJECT_SOURCE_DIR}/inc/consts.h
+  ${PROJECT_SOURCE_DIR}/inc/laplace_minimax.h
+  ${PROJECT_SOURCE_DIR}/src/dd128_arithmetics.F90
+  ${PROJECT_SOURCE_DIR}/src/dd128_linalg.F90
+  ${PROJECT_SOURCE_DIR}/src/lap_rderror.F90
+  ${PROJECT_SOURCE_DIR}/src/lap_rddata.F90
+  ${PROJECT_SOURCE_DIR}/src/lap_paraopt.F90
+  ${PROJECT_SOURCE_DIR}/src/lap_maehly.F90
+  ${PROJECT_SOURCE_DIR}/src/lap_rmsd.F90
+  ${PROJECT_SOURCE_DIR}/src/lap_numlap.F90
+  ${PROJECT_SOURCE_DIR}/src/laplace_minimax.F90
 )
 
 # test source files
-set(TEST_SOURCES
-    ${PROJECT_SOURCE_DIR}/src/test_laplace.F90
-)
+set(TEST_SOURCES ${PROJECT_SOURCE_DIR}/src/test_laplace.F90)
 
 # data files
-set(DATA
-    ${PROJECT_SOURCE_DIR}/data/init_error.txt
-    ${PROJECT_SOURCE_DIR}/data/init_para.txt
+set(
+  DATA
+  ${PROJECT_SOURCE_DIR}/data/init_error.txt
+  ${PROJECT_SOURCE_DIR}/data/init_para.txt
 )
 
 # creates test suite
@@ -60,22 +59,27 @@ add_executable(test_laplace ${TEST_SOURCES} ${SOURCES})
 add_library(laplace-minimax STATIC ${SOURCES})
 
 # take care of test
-find_program (BASH_PROGRAM bash)
+find_program(BASH_PROGRAM bash)
 
-if (BASH_PROGRAM)
-  add_test (test_laplace-minimax ${BASH_PROGRAM} ${PROJECT_SOURCE_DIR}/bin/run_test.sh)
-endif (BASH_PROGRAM)
+if(BASH_PROGRAM)
+  add_test(
+    test_laplace-minimax
+    ${BASH_PROGRAM}
+    ${PROJECT_SOURCE_DIR}/bin/run_test.sh
+  )
+endif(BASH_PROGRAM)
 
 # Install static library
 install(TARGETS laplace-minimax ARCHIVE DESTINATION lib)
-        
+
 # Install header (fortran interface)
-install(FILES ${PROJECT_SOURCE_DIR}/inc/laplace_minimax.h 
-        DESTINATION include/laplace-minimax)
+install(
+  FILES ${PROJECT_SOURCE_DIR}/inc/laplace_minimax.h
+  DESTINATION include/laplace-minimax
+)
 
 # copy data files
 install(FILES ${DATA} DESTINATION data)
 
 # .. if this has any effect?
 set(ENV{LAPLACE_ROOT} ${CMAKE_INSTALL_PREFIX})
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 # project name
 project(laplace-minimax Fortran)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,17 @@ set(
   ${PROJECT_SOURCE_DIR}/src/laplace_minimax.F90
 )
 
-# test source files
-set(TEST_SOURCES ${PROJECT_SOURCE_DIR}/src/test_laplace.F90)
+# the static library
+add_library(laplace-minimax STATIC ${SOURCES})
+
+# Install static library
+install(TARGETS laplace-minimax ARCHIVE DESTINATION lib)
+
+# Install header (fortran interface)
+install(
+  FILES ${PROJECT_SOURCE_DIR}/inc/laplace_minimax.h
+  DESTINATION include/laplace-minimax
+)
 
 # data files
 set(
@@ -52,11 +61,17 @@ set(
   ${PROJECT_SOURCE_DIR}/data/init_para.txt
 )
 
+# copy data files
+install(FILES ${DATA} DESTINATION data)
+
+# .. if this has any effect?
+set(ENV{LAPLACE_ROOT} ${CMAKE_INSTALL_PREFIX})
+
+# test source files
+set(TEST_SOURCES ${PROJECT_SOURCE_DIR}/src/test_laplace.F90)
+
 # creates test suite
 add_executable(test_laplace ${TEST_SOURCES} ${SOURCES})
-
-# the static library
-add_library(laplace-minimax STATIC ${SOURCES})
 
 # take care of test
 find_program(BASH_PROGRAM bash)
@@ -68,18 +83,3 @@ if(BASH_PROGRAM)
     ${PROJECT_SOURCE_DIR}/bin/run_test.sh
   )
 endif(BASH_PROGRAM)
-
-# Install static library
-install(TARGETS laplace-minimax ARCHIVE DESTINATION lib)
-
-# Install header (fortran interface)
-install(
-  FILES ${PROJECT_SOURCE_DIR}/inc/laplace_minimax.h
-  DESTINATION include/laplace-minimax
-)
-
-# copy data files
-install(FILES ${DATA} DESTINATION data)
-
-# .. if this has any effect?
-set(ENV{LAPLACE_ROOT} ${CMAKE_INSTALL_PREFIX})

--- a/bin/run_test.sh
+++ b/bin/run_test.sh
@@ -21,7 +21,7 @@ fi
 
 CHECK_SCRIPT='laplace-minimax.check'
 LOG_FILE='/tmp/laplace-minimax.log'
-TEST_PROG='./bin/test_laplace'
+TEST_PROG='./test_laplace'
 
 #######################################################################
 # run the test


### PR DESCRIPTION
Without this, using CMake 4+ will error.  3.10 is arguably too old, since the oldest version i could find on pkgs.org is 3.18 in Debian 11.  It currently gives a deprecation warning and in a few years will give an error, so this is just a stopgap.

The PR also rearranges the CMake config so that sources don't need to be recompiled for the test binary.

These updates come before a commit that applies the formatter https://github.com/blankspruce/gersemi.